### PR TITLE
feat(hiscore): Add command to get single user hiscores ad-hoc

### DIFF
--- a/discord/bot.go
+++ b/discord/bot.go
@@ -65,6 +65,11 @@ func StartBotListener() {
 			if modalSubmitFunction != nil {
 				modalSubmitFunction(s, i)
 			}
+		case discordgo.InteractionApplicationCommandAutocomplete:
+			autocompleteFunction := GetAutocompleteHandler(i.ApplicationCommandData().Name)
+			if autocompleteFunction != nil {
+				autocompleteFunction(s, i)
+			}
 		default:
 			log.Printf("No handler for Interaction Type %s\n", i.Type)
 		}

--- a/discord/command_hiscore.go
+++ b/discord/command_hiscore.go
@@ -1,0 +1,156 @@
+package discord
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/michohl/osrs-clan-leaderboard/hiscores"
+	"github.com/michohl/osrs-clan-leaderboard/jet_schemas/model"
+	"github.com/michohl/osrs-clan-leaderboard/storage"
+	"github.com/michohl/osrs-clan-leaderboard/types"
+)
+
+// HiscoreCommandInfo is the information we'll use to
+// "register" this command with Discord so it appears
+// as an option to end users
+var HiscoreCommandInfo = discordgo.ApplicationCommand{
+	Name:        "hiscore",
+	Description: "Get the hiscore(s) for a single user for specified activities",
+	Type:        discordgo.ChatApplicationCommand,
+	Options: []*discordgo.ApplicationCommandOption{
+		{
+			Name:         "rsn",
+			Description:  "The RSN of the user you want to get a hiscore of",
+			Type:         discordgo.ApplicationCommandOptionString,
+			Required:     true,
+			Autocomplete: true,
+		},
+		{
+			Name:        "activities",
+			Description: "A comma separated list of activities to lookup",
+			Type:        discordgo.ApplicationCommandOptionString,
+			Required:    true,
+		},
+	},
+}
+
+// HiscoreAutocompleteHandler is how we populate server tailored autocomplete options
+func HiscoreAutocompleteHandler(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	choices := []*discordgo.ApplicationCommandOptionChoice{}
+
+	allUsers, err := storage.FetchAllUsers(i.GuildID)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	for _, u := range allUsers {
+		choices = append(choices, &discordgo.ApplicationCommandOptionChoice{
+			Name:  u.OsrsUsername,
+			Value: u.OsrsUsername,
+		})
+	}
+
+	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionApplicationCommandAutocompleteResult,
+		Data: &discordgo.InteractionResponseData{
+			Choices: choices,
+		},
+	})
+
+	if err != nil {
+		log.Println(err)
+		return
+	}
+}
+
+// HiscoreHandler will take a command request from Discord and translate
+// that into an action. This is where we decide if we're taking action
+// or if Discord is just asking what autocomplete options are available
+func HiscoreHandler(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	switch i.Type {
+	case discordgo.InteractionApplicationCommand:
+		hiscoreCommand(s, i)
+	}
+}
+
+// Actually do the command the user is requesting
+func hiscoreCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	// Defer our message so we have time to do processing
+	// before discord times us out (we get 15 minutes now)
+	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: "Generating hiscores message data...",
+		},
+	})
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	data := i.ApplicationCommandData().Options
+	osrsUsername := data[0].StringValue()
+	activities := strings.Split(data[1].StringValue(), ",")
+
+	discoveredErrors := ""
+
+	osrsUser, err := storage.FetchUser(i.GuildID, hiscores.EncodeRSN(osrsUsername))
+	if err != nil {
+		log.Println(err)
+
+		discoveredErrors = fmt.Sprintf(
+			"%s\n* %s",
+			discoveredErrors,
+			fmt.Sprintf("Failed to find details of user '%s'. Make sure you have done /assign", osrsUsername),
+		)
+	}
+
+	hiscoresEmbeds, err := hiscores.FormatEmbeds(activities, []model.Users{osrsUser})
+	if err != nil {
+		discoveredErrors = fmt.Sprintf(
+			"%s\n* %s",
+			discoveredErrors,
+			err,
+		)
+	}
+
+	if discoveredErrors != "" {
+
+		toolsEmoji := types.ApplicationEmojis["tools"]
+		_, err = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+			Content: discoveredErrors,
+			Components: []discordgo.MessageComponent{
+				discordgo.ActionsRow{
+					Components: []discordgo.MessageComponent{
+						discordgo.Button{
+							Emoji: &discordgo.ComponentEmoji{
+								Name: toolsEmoji.Name,
+								ID:   toolsEmoji.ID,
+							},
+							Label: "List of All Skills and Activities",
+							Style: discordgo.LinkButton,
+							URL:   "https://runescape.wiki/w/Application_programming_interface#Old_School_Hiscores",
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			log.Println(err)
+			return
+		}
+
+		return
+	}
+
+	_, err = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+		Embeds: hiscoresEmbeds,
+	})
+	if err != nil {
+		log.Println(err)
+		return
+	}
+}

--- a/discord/handler.go
+++ b/discord/handler.go
@@ -13,6 +13,7 @@ var commands = []*discordgo.ApplicationCommand{
 	&ConfigureCommandInfo,
 	&AssignCommandInfo,
 	&PostHiscoresCommandInfo,
+	&HiscoreCommandInfo,
 }
 
 // CommandHandler is the contract any function we want to use as a handler must satisfy
@@ -24,6 +25,11 @@ var commandHandlers = map[string]CommandHandler{
 	"configure": ConfigureHandler,
 	"assign":    AssignHandler,
 	"post":      PostHiscoresHandler,
+	"hiscore":   HiscoreHandler,
+}
+
+var autocompleteHandlers = map[string]CommandHandler{
+	"hiscore": HiscoreAutocompleteHandler,
 }
 
 // GetCommandHandler takes the user specified command and returns
@@ -50,5 +56,16 @@ func GetModalSubmitHandler(customID string) CommandHandler {
 		log.Printf("No Modal Submit Handler that matches %s\n", customID)
 	}
 
+	return nil
+}
+
+// GetAutocompleteHandler takes the user specified command and returns
+// the relevant function responsible for generating autocomplete options
+func GetAutocompleteHandler(command string) CommandHandler {
+	if h, ok := autocompleteHandlers[command]; ok {
+		return h
+	}
+
+	log.Printf("No Command Handler defined for %s\n", command)
 	return nil
 }

--- a/hiscores/generate.go
+++ b/hiscores/generate.go
@@ -25,6 +25,18 @@ func GenerateHiscoresFields(server model.Servers) ([]*discordgo.MessageEmbed, er
 		return nil, err
 	}
 
+	embeds, err := FormatEmbeds(allActivities, allUsers)
+	if err != nil {
+		return nil, err
+	}
+
+	return embeds, nil
+}
+
+// FormatEmbeds takes a list of activities and users and formats that information into our final
+// set of embeds that we'll pass back to discord to present to the user in the message
+func FormatEmbeds(allActivities []string, allUsers []model.Users) ([]*discordgo.MessageEmbed, error) {
+
 	userHiscores, err := GetUserHiscores(allUsers)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Summary

Add a new `/hiscore [rsn] [activities]` command that users can call to have the bot reply publicly with that users hiscores. This will be similar output to the scheduled message but will only be tailored to one user. 

This is not limited to the server's configured activities and can be used for any activity.

This is limited to only users who have enrolled with `/assign` since otherwise we would be missing their account status information. Also it's good motivation to get people to enroll in the "clan leaderboards" :) 

This PR required adding some new bot infrastructure to support auto complete commands. This is how we get the command to show a list of options that are valid based on the server the command is being invoked from.

Resolves https://github.com/michohl/osrs-clan-leaderboard/issues/9

# Evidence of Test

Autocomplete options:

<img width="803" height="509" alt="image" src="https://github.com/user-attachments/assets/26851000-d55d-4b4a-940f-2e0dd5950b0c" />

Single user single activity

```
/hiscore dusto29 overall
```

<img width="454" height="197" alt="image" src="https://github.com/user-attachments/assets/472ad104-fd1c-40bf-ae68-37bf506c8c51" />

Single user multiple activities

```
/hiscore TheBigBadOpe overall,vorkath
```

<img width="507" height="321" alt="image" src="https://github.com/user-attachments/assets/f3da6875-dd36-4269-8328-8e7597cca5c2" />


Errors when the user is not setup on the current server or when the activity is invalid:

```
/assign bogusUser bogusActivity
```

<img width="733" height="189" alt="image" src="https://github.com/user-attachments/assets/54468511-507b-426b-bb6a-34cc17012998" />

