### PR TITLE
feat(unassign): Add new unassign command

### DIFF
--- a/discord/command_unassign.go
+++ b/discord/command_unassign.go
@@ -1,0 +1,78 @@
+package discord
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/michohl/osrs-clan-leaderboard/hiscores"
+	"github.com/michohl/osrs-clan-leaderboard/storage"
+
+	"github.com/michohl/osrs-clan-leaderboard/jet_schemas/model"
+)
+
+// UnassignCommandInfo builds an association between OSRS
+// usernames and discord users
+var UnassignCommandInfo = discordgo.ApplicationCommand{
+	Name:        "unassign",
+	Description: "Unassign an OSRS user to a discord member",
+	Type:        discordgo.ChatApplicationCommand,
+	Options: []*discordgo.ApplicationCommandOption{
+		{
+			Name:         "osrs_user",
+			Description:  "The user's OSRS username",
+			Type:         discordgo.ApplicationCommandOptionString,
+			Required:     true,
+			Autocomplete: true,
+		},
+	},
+}
+
+// UnassignHandler will take a command request from Discord and translate
+// that into an action. This is where we decide if we're taking action
+// or if Discord is just asking what autocomplete options are available
+func UnassignHandler(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	switch i.Type {
+	case discordgo.InteractionApplicationCommand:
+		unassignCommand(s, i)
+	}
+}
+
+// Actually do the command the user is requesting
+func unassignCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+
+	data := i.ApplicationCommandData().Options
+	osrsUsername := data[0].StringValue()
+
+	err := storage.RemoveUser(model.Users{
+		OsrsUsernameKey: hiscores.EncodeRSN(osrsUsername),
+		ServerID:        i.GuildID,
+	})
+	if err != nil {
+		err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: fmt.Sprintf("OSRS User %s couldn't be unassigned...", osrsUsername),
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+		if err != nil {
+			log.Println(err)
+			return
+		}
+
+		return
+	}
+
+	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: fmt.Sprintf("OSRS User %s unassigned", osrsUsername),
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	})
+	if err != nil {
+		log.Println(err)
+		return
+	}
+}

--- a/discord/handler.go
+++ b/discord/handler.go
@@ -12,6 +12,7 @@ var commands = []*discordgo.ApplicationCommand{
 	&PingCommandInfo,
 	&ConfigureCommandInfo,
 	&AssignCommandInfo,
+	&UnassignCommandInfo,
 	&PostHiscoresCommandInfo,
 	&HiscoreCommandInfo,
 }
@@ -24,12 +25,14 @@ var commandHandlers = map[string]CommandHandler{
 	"ping":      PingHandler,
 	"configure": ConfigureHandler,
 	"assign":    AssignHandler,
+	"unassign":  UnassignHandler,
 	"post":      PostHiscoresHandler,
 	"hiscore":   HiscoreHandler,
 }
 
 var autocompleteHandlers = map[string]CommandHandler{
-	"hiscore": HiscoreAutocompleteHandler,
+	"hiscore":  HiscoreAutocompleteHandler,
+	"unassign": HiscoreAutocompleteHandler,
 }
 
 // GetCommandHandler takes the user specified command and returns

--- a/storage/database.go
+++ b/storage/database.go
@@ -151,6 +151,31 @@ func EnrollUser(user model.Users) error {
 	return nil
 }
 
+// RemoveUser removes a user from a specific server
+func RemoveUser(user model.Users) error {
+	log.Printf("Request received to remove OSRS user %s from server %s\n", user.OsrsUsername, user.ServerID)
+
+	db, err := sql.Open("sqlite3", DBFilePath)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	sqlStmt := table.Users.
+		DELETE().
+		WHERE(table.Users.ServerID.
+			EQ(sqlite.String(user.ServerID)).
+			AND(table.Users.OsrsUsernameKey.EQ(sqlite.String(user.OsrsUsernameKey))),
+		)
+
+	_, err = sqlStmt.Exec(db)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // FetchAllServers gets all enrolled servers from the database
 func FetchAllServers() ([]model.Servers, error) {
 	db, err := sql.Open("sqlite3", DBFilePath)


### PR DESCRIPTION
Currently if you enroll in the system on a server there is no way to get out. This just allows for removing users from the database.

New command is `/unassign [osrs_username]`

Resolves https://github.com/michohl/osrs-clan-leaderboard/issues/6