### PR TITLE
feat(comand_hiscore): Allow for using more specific leaderboards when possible

### DIFF
--- a/discord/command_assign.go
+++ b/discord/command_assign.go
@@ -87,7 +87,7 @@ func assignCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	osrsUsername := data[1].StringValue()
 	osrsAccountType := data[2].StringValue()
 
-	_, err := hiscores.GetPlayerHiscores(osrsUsername)
+	_, err := hiscores.GetPlayerHiscores(osrsUsername, "main")
 	if err != nil {
 		err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,

--- a/discord/command_hiscore.go
+++ b/discord/command_hiscore.go
@@ -33,6 +33,34 @@ var HiscoreCommandInfo = discordgo.ApplicationCommand{
 			Type:        discordgo.ApplicationCommandOptionString,
 			Required:    true,
 		},
+		{
+			Name:        "leaderboard",
+			Description: "Which leaderboard you want to check hiscores on",
+			Type:        discordgo.ApplicationCommandOptionString,
+			Required:    false,
+			Choices: []*discordgo.ApplicationCommandOptionChoice{
+				{
+					Name:  "Use Default for Acccount Type",
+					Value: "",
+				},
+				{
+					Name:  "Main",
+					Value: "main",
+				},
+				{
+					Name:  "Ironman",
+					Value: "ironman",
+				},
+				{
+					Name:  "Ultimate Ironman",
+					Value: "ultimate_ironman",
+				},
+				{
+					Name:  "Hardcore Ironman",
+					Value: "hardcore_ironman",
+				},
+			},
+		},
 	},
 }
 
@@ -95,6 +123,16 @@ func hiscoreCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	osrsUsername := data[0].StringValue()
 	activities := strings.Split(data[1].StringValue(), ",")
 
+	accountType := ""
+	if len(data) > 2 {
+		accountType = data[2].StringValue()
+	}
+
+	if accountType == "" {
+		fmt.Println("No account type provided. Making a guess")
+		accountType = hiscores.GuessUserAccountType(osrsUsername)
+	}
+
 	discoveredErrors := ""
 
 	osrsUser, err := storage.FetchUser(i.GuildID, hiscores.EncodeRSN(osrsUsername))
@@ -104,13 +142,13 @@ func hiscoreCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			OsrsUsernameKey: hiscores.EncodeRSN(osrsUsername),
 			OsrsUsername:    osrsUsername,
 			ServerID:        i.GuildID,
-			OsrsAccountType: "", // TODO: Determine at runtime account type
+			OsrsAccountType: accountType,
 			DiscordUsername: "",
 			DiscordUserID:   "",
 		}
 	}
 
-	userHiscores, err := hiscores.GetUserHiscores([]model.Users{osrsUser})
+	userHiscores, err := hiscores.GetUserHiscores([]model.Users{osrsUser}, false)
 	if err != nil {
 		log.Println(err)
 

--- a/discord/post_hiscores.go
+++ b/discord/post_hiscores.go
@@ -40,7 +40,7 @@ func PostHiscoresMessages(serverID string, s *discordgo.Session) error {
 		return err
 	}
 
-	userHiscores, err := hiscores.GetUserHiscores(allUsers)
+	userHiscores, err := hiscores.GetUserHiscores(allUsers, true)
 	if err != nil {
 		return err
 	}

--- a/hiscores/api.go
+++ b/hiscores/api.go
@@ -5,17 +5,23 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/michohl/osrs-clan-leaderboard/types"
 )
 
-// HiscoreURLs are the endpoints we reach out to to get Hiscores from Jagex
-var HiscoreURLs = map[string]string{
-	"ironman":          "https://secure.runescape.com/m=hiscore_oldschool_ironman/index_lite.json",
-	"hardcore_ironman": "https://secure.runescape.com/m=hiscore_oldschool_hardcore_ironman/index_lite.json",
-	"ultimate_ironman": "https://secure.runescape.com/m=hiscore_oldschool_ultimate/index_lite.json",
-	"main":             "https://secure.runescape.com/m=hiscore_oldschool/index_lite.json",
+// HiscoreModes is the `m=` parameter on our API URI we reach out to to get Hiscores from Jagex
+var HiscoreModes = map[string]string{
+	"hardcore_ironman": "hiscore_oldschool_hardcore_ironman",
+	"ultimate_ironman": "hiscore_oldschool_ultimate",
+	"ironman":          "hiscore_oldschool_ironman",
+	"main":             "hiscore_oldschool",
+
+	// These modes don't have their own leaderboard from the API so we just have to use the main
+	// "unranked_group_ironman": "hiscore_oldschool",
+	// "group_ironman":          "hiscore_oldschool",
+	// "hardcore_group_ironman": "hiscore_oldschool",
 }
 
 // EncodeRSN takes the "human friendly" version
@@ -28,16 +34,22 @@ func EncodeRSN(username string) string {
 // GetPlayerHiscores makes a call to the Jagex provided
 // API endpoint that returns the hiscores for one specific user.
 // Documentation: https://runescape.wiki/w/Application_programming_interface#Old_School_Hiscores
-func GetPlayerHiscores(username string) (types.Hiscores, error) {
+func GetPlayerHiscores(username string, accountType string) (types.Hiscores, error) {
 
 	encodedUsername := EncodeRSN(username)
 
 	var userHiscores types.Hiscores
 
-	// We always want to use the main leaderboards for our local rankings
+	mode, ok := HiscoreModes[accountType]
+	if !ok {
+		fmt.Printf("Account Type '%s' does not have an associated Hiscores mode. Defaulting to Overall hiscores\n", accountType)
+		mode = "main"
+	}
+
 	resp, err := http.Get(
-		fmt.Sprintf("%s?player=%s", HiscoreURLs["main"], encodedUsername),
+		fmt.Sprintf("https://secure.runescape.com/m=%s/index_lite.json?player=%s", mode, encodedUsername),
 	)
+
 	if err != nil {
 		return types.Hiscores{}, err
 	}
@@ -59,7 +71,7 @@ func GetPlayerHiscores(username string) (types.Hiscores, error) {
 // GetAllSkills will return all the valid skill options that the API
 // can possibly return
 func GetAllSkills() ([]string, error) {
-	hs, err := GetPlayerHiscores("sample")
+	hs, err := GetPlayerHiscores("sample", "main")
 	if err != nil {
 		return []string{}, err
 	}
@@ -75,7 +87,7 @@ func GetAllSkills() ([]string, error) {
 // GetAllActivities will return all the valid skill options that the API
 // can possibly return
 func GetAllActivities() ([]string, error) {
-	hs, err := GetPlayerHiscores("sample")
+	hs, err := GetPlayerHiscores("sample", "main")
 	if err != nil {
 		return []string{}, err
 	}
@@ -86,4 +98,45 @@ func GetAllActivities() ([]string, error) {
 	}
 
 	return discoveredActivities, nil
+}
+
+// GuessUserAccountType takes a RSN and checks all the available
+// leaderboards to see if we can determine what kind of account
+// the user actually is. Default to main if nothing more suitable found
+func GuessUserAccountType(username string) string {
+	encodedUsername := EncodeRSN(username)
+
+	accountTypes := sortAccountTypes()
+
+	for _, accountType := range accountTypes {
+		mode := HiscoreModes[accountType]
+		resp, _ := http.Get(
+			fmt.Sprintf("https://secure.runescape.com/m=%s/index_lite.json?player=%s", mode, encodedUsername),
+		)
+
+		if resp.StatusCode != 404 {
+			return accountType
+		}
+	}
+
+	return "main"
+}
+
+// sortAccountTypes takes the HiscoreModes and sorts the keys
+// to prioritize the specialized game modes and then end with
+// ironman then main.
+func sortAccountTypes() []string {
+
+	lowPriorityAccountTypes := []string{"ironman", "main"}
+	accountTypes := []string{}
+
+	for accountType := range HiscoreModes {
+		if !slices.Contains(lowPriorityAccountTypes, accountType) {
+			accountTypes = append(accountTypes, accountType)
+		}
+	}
+
+	slices.Sort(accountTypes)
+	return append(accountTypes, lowPriorityAccountTypes...)
+
 }

--- a/hiscores/generate.go
+++ b/hiscores/generate.go
@@ -121,7 +121,7 @@ func FormatEmbeds(activity string, userHiscores map[model.Users]types.Hiscores, 
 
 // GetUserHiscores takes a list of users and returns a map populated with all of the
 // hiscores for each user
-func GetUserHiscores(allUsers []model.Users) (map[model.Users]types.Hiscores, error) {
+func GetUserHiscores(allUsers []model.Users, forceNormalizedLeaderboard bool) (map[model.Users]types.Hiscores, error) {
 	var userHiscores map[model.Users]types.Hiscores = make(map[model.Users]types.Hiscores)
 
 	var wg sync.WaitGroup
@@ -131,8 +131,16 @@ func GetUserHiscores(allUsers []model.Users) (map[model.Users]types.Hiscores, er
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			log.Printf("Getting rank for user %s\n", user.OsrsUsername)
-			userHS, err := GetPlayerHiscores(user.OsrsUsernameKey)
+
+			var accountType string
+			if forceNormalizedLeaderboard {
+				accountType = "main"
+			} else {
+				accountType = user.OsrsAccountType
+			}
+
+			log.Printf("Getting rank for user %s on %s leaderboards\n", user.OsrsUsername, accountType)
+			userHS, err := GetPlayerHiscores(user.OsrsUsernameKey, accountType)
 			if err != nil {
 				// If a user changes their RSN we don't want to break the entire process.
 				// We'll just exclude them from the results.


### PR DESCRIPTION
Currently every request is forced to use the "overall" leaderboards which might undermine accomplishments for niche account types where their ranking is much more noteworthy.

Now `/hiscore` will default to attempting to discover the user's account type by iterating through the niche leaderboards and seeing if the user has valid rankings in each. If they don't then it'll fall back to the "main" leaderboards.

The `/hiscore` command now also has an optional input where you can override which leaderboard you want to see the rating(s) for instead of using the assumed default.

The override option is hidden behind a `+1 more` which when clicked on shows the override input. This should make it so user's don't get confused and think they have to provide an input when they don't.

<img width="570" height="238" alt="image" src="https://github.com/user-attachments/assets/79c54720-09ff-4234-80a0-2473d9136d00" />

We will still continue to normalize all scheduled hiscore messages to use the Overall leaderboards since it would not be clear visually which leaderboard was used for each user.

Also group ironmen are excluded from this new feature because they don't actually have their own leaderboard. They don't even fall under the ironman umbrella :/
 